### PR TITLE
Bump aws-sdk dependency version to 2.2.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "postversion": "git push && git push --tags && npm publish"
   },
   "dependencies": {
-    "aws-sdk": "2.1.26",
+    "aws-sdk": "2.2.15",
     "underscore": "1.8.3",
     "underscore.deferred": "0.4.0"
   },


### PR DESCRIPTION
I'm using this package in an AWS Lambda, and it forces an older version of AWS SDK  where `AWS.DynamoDB.DocumentClient` is not supported. I want to use both :)
